### PR TITLE
fix: load calls after login

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -136,7 +136,7 @@ function App() {
 
   useEffect(() => {
     getUserCalls();
-  }, [])
+  }, [loggedIn]);
 
   
 


### PR DESCRIPTION
Исправлено: карточки теперь загружаются при авторизации, а не при загрузке страницы